### PR TITLE
Print logs only when blocked or dump is saved

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -9,7 +9,7 @@
     </target>
 
     <target name="jar" depends="compile">
-        <property name="version" value="0.9.1"/>
+        <property name="version" value="1.0.0"/>
         <mkdir dir="dist"/>
         <jar destfile="dist/jvm-monitoring-agent-${version}.jar" basedir="build/classes">
             <manifest>

--- a/src/com/toptal/jvm/monitoring/Agent.java
+++ b/src/com/toptal/jvm/monitoring/Agent.java
@@ -1,5 +1,6 @@
 /**
  *  Copyright 2017 Michal Papis <mpapis@gmail.com>
+ *  Copyright 2019 Alexey Shein <alexey.shein@toptal.com>
  *
  *  This file is part of JVM Monitoring Agent.
  *
@@ -119,7 +120,9 @@ public final class Agent extends TimerTask{
             lastSave = loopStartTime;
             msg += " - saved dump: "+dumpFileName;
         }
-        log(msg);
+	if (blockedToLong || savedDump) {
+            log(msg);
+	}
     }
 
     private void log(String msg)


### PR DESCRIPTION
Let's remove all these `It took 5ms` that are cluttering Jenkins logs.