### PR TITLE
Filter Blocked Threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Specifies how long thread needs to be blocked before dumps will be saved. (Milli
 
 Specifies delay between saving consecutive threads dumps. (Milliseconds)
 
+### `filterRegex=...`
+
+Specifies a regular expression to filter known blocked threads. (Milliseconds)
+
 
 # Examples
 


### PR DESCRIPTION
We need to filter the BLOCKED threads because some http-threads are always blocked. Based on this change we use the following configuration for the agent:

```
threshold=5000,interval=10000,filterRegex="^qtp",debug,path="%KARAF_HOME%/server/logs"
```

With this config a thread dump is only created when a thread that not starts with **qtp** is BLOCKED. Please check and pull request, hopefully this is fine and can be integrated in a final release!